### PR TITLE
Only run the release action when the latest commit message contains `[ci]`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   download-requirements:
     runs-on: ubuntu-latest
+    if: "contains(github.event.head_commit.message, '[ci]')"
 
     env:
       RELEASE_TAG: "v0.0.0-dev"


### PR DESCRIPTION
Eg
- [ci] version bump
- run [ci]

Or whatever you want, as long as it contains `[ci]`