### PR TITLE
Revert "Only run the release action when the latest commit message contains ci"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ permissions:
 jobs:
   download-requirements:
     runs-on: ubuntu-latest
-    if: "contains(github.event.head_commit.message, '[ci]')"
 
     env:
       RELEASE_TAG: "v0.0.0-dev"


### PR DESCRIPTION
Reverts exconvinced/revanced-web-app#3